### PR TITLE
[Feat] 영상 선택 UI 구현

### DIFF
--- a/App/Project.swift
+++ b/App/Project.swift
@@ -24,7 +24,8 @@ let infoPlist: [String: Plist.Value] = [
         ],
       ]
     ]
-  ]
+  ],
+  "NSPhotoLibraryUsageDescription": "앱에서 사진 라이브러리에 접근하려면 권한이 필요합니다."
 ]
 
 private let moduleName = "App"

--- a/App/Project.swift
+++ b/App/Project.swift
@@ -12,6 +12,12 @@ let infoPlist: [String: Plist.Value] = [
   "CFBundleShortVersionString": "1.0.0",
   "CFBundleVersion": "1",
   "CFBundleDisplayName": "Recordy",
+  "CFBundleURLTypes": [
+    [
+      "CFBundleTypeRole": "Editor",
+      "CFBundleURLSchemes": ["kakao$(KAKAO_NATIVE_APP_KEY)"]
+    ],
+  ],
   "UIMainStoryboardFile": "",
   "UILaunchStoryboardName": "LaunchScreen.storyboard",
   "UIApplicationSceneManifest": [
@@ -24,8 +30,20 @@ let infoPlist: [String: Plist.Value] = [
         ],
       ]
     ]
-  ]
+  ],
+  "LSApplicationQueriesSchemes": [
+    "kakaokompassauth",
+    "kakaolink",
+    "kakao$(KAKAO_NATIVE_APP_KEY)"
+  ],
+  "KAKAO_NATIVE_APP_KEY": "$(KAKAO_NATIVE_APP_KEY)"
 ]
+
+private let settings = Settings.settings(configurations: [
+  .debug(name: "Debug", xcconfig:
+      .relativeToRoot("App/Config/Secrets.xcconfig")),
+  .release(name: "Release", xcconfig: .relativeToRoot("App/Config/Secrets.xcconfig")),
+])
 
 private let moduleName = "App"
 
@@ -40,6 +58,10 @@ let project = Project.makeModule(
     .Project.Common,
     .Project.Core,
     .Project.Data,
-    .Project.Presentation
-  ]
+    .Project.Presentation,
+    .external(name: "KakaoSDKAuth", condition: .none),
+    .external(name: "KakaoSDKCommon", condition: .none),
+    .external(name: "KakaoSDKUser", condition: .none)
+  ],
+  settings: settings
 )

--- a/App/Project.swift
+++ b/App/Project.swift
@@ -36,8 +36,7 @@ let infoPlist: [String: Plist.Value] = [
     "kakaolink",
     "kakao$(KAKAO_NATIVE_APP_KEY)"
   ],
-  "KAKAO_NATIVE_APP_KEY": "$(KAKAO_NATIVE_APP_KEY)"
-  ],
+  "KAKAO_NATIVE_APP_KEY": "$(KAKAO_NATIVE_APP_KEY)",
   "NSPhotoLibraryUsageDescription": "앱에서 사진 라이브러리에 접근하려면 권한이 필요합니다."
 ]
 

--- a/App/Sources/AppDelegate.swift
+++ b/App/Sources/AppDelegate.swift
@@ -8,5 +8,16 @@
 
 import UIKit
 
+import KakaoSDKCommon
+
 @main
-class AppDelegate: UIResponder, UIApplicationDelegate { }
+class AppDelegate: UIResponder, UIApplicationDelegate {
+  func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil
+  ) -> Bool {
+    let nativeAppKey = Bundle.main.infoDictionary?["KAKAO_NATIVE_APP_KEY"] ?? ""
+    KakaoSDK.initSDK(appKey: nativeAppKey as! String)
+    return true
+  }
+}

--- a/App/Sources/SceneDelegate.swift
+++ b/App/Sources/SceneDelegate.swift
@@ -8,9 +8,24 @@
 
 import UIKit
 
+import Presentation
+
+import KakaoSDKAuth
+
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
   var window: UIWindow?
+
+  func scene(
+    _ scene: UIScene,
+    openURLContexts URLContexts: Set<UIOpenURLContext>
+  ) {
+    if let url = URLContexts.first?.url {
+      if (AuthApi.isKakaoTalkLoginUrl(url)) {
+        _ = AuthController.handleOpenUrl(url: url)
+          }
+      }
+  }
 
   func scene(
     _ scene: UIScene,

--- a/Common/Resources/Asset.xcassets/Color 1.colorset/Contents.json
+++ b/Common/Resources/Asset.xcassets/Color 1.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Common/Resources/Asset.xcassets/Color.colorset/Contents.json
+++ b/Common/Resources/Asset.xcassets/Color.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFE"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFE"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Common/Resources/Asset.xcassets/recordyBlack.colorset/Contents.json
+++ b/Common/Resources/Asset.xcassets/recordyBlack.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Common/Sources/Base/BaseNavigationController.swift
+++ b/Common/Sources/Base/BaseNavigationController.swift
@@ -6,4 +6,24 @@
 //  Copyright © 2024 com.recordy. All rights reserved.
 //
 
-import Foundation
+import UIKit
+
+public class BaseNavigationController: UINavigationController {
+  public override func viewDidLoad() {
+    super.viewDidLoad()
+    configureNavigationBar()
+  }
+
+  private func configureNavigationBar() {
+    let appearance = UINavigationBarAppearance()
+    appearance.backgroundColor = .black
+    appearance.shadowColor = UIColor.clear
+    navigationBar.standardAppearance = appearance
+    navigationBar.scrollEdgeAppearance = appearance
+    navigationBar.titleTextAttributes = [
+      NSAttributedString.Key.foregroundColor: CommonAsset.recordyWhite,
+      NSAttributedString.Key.font: RecordyFont.title2
+    ]
+    navigationItem.backButtonDisplayMode = .minimal
+  }
+}

--- a/Common/Sources/Base/BaseNavigationController.swift
+++ b/Common/Sources/Base/BaseNavigationController.swift
@@ -1,0 +1,9 @@
+//
+//  BaseNavigationController.swift
+//  Common
+//
+//  Created by 한지석 on 7/4/24.
+//  Copyright © 2024 com.recordy. All rights reserved.
+//
+
+import Foundation

--- a/Common/Sources/Extension/UICollectionViewCell+.swift
+++ b/Common/Sources/Extension/UICollectionViewCell+.swift
@@ -6,4 +6,10 @@
 //  Copyright © 2024 com.recordy. All rights reserved.
 //
 
-import Foundation
+import UIKit
+
+extension UICollectionViewCell {
+    public static var cellIdentifier: String {
+        return String(describing: self)
+    }
+}

--- a/Common/Sources/Extension/UICollectionViewCell+.swift
+++ b/Common/Sources/Extension/UICollectionViewCell+.swift
@@ -1,0 +1,9 @@
+//
+//  UICollectionViewCell+.swift
+//  Common
+//
+//  Created by 한지석 on 7/2/24.
+//  Copyright © 2024 com.recordy. All rights reserved.
+//
+
+import Foundation

--- a/Common/Sources/Extension/UIView+.swift
+++ b/Common/Sources/Extension/UIView+.swift
@@ -6,4 +6,11 @@
 //  Copyright © 2024 com.recordy. All rights reserved.
 //
 
-import Foundation
+import UIKit
+
+extension UIView {
+  public func cornerRadius(_ cgFloat: CGFloat) {
+    self.layer.masksToBounds = true
+    self.layer.cornerRadius = cgFloat
+  }
+}

--- a/Common/Sources/Extension/UIView+.swift
+++ b/Common/Sources/Extension/UIView+.swift
@@ -1,0 +1,9 @@
+//
+//  UIView+.swift
+//  Common
+//
+//  Created by 한지석 on 7/4/24.
+//  Copyright © 2024 com.recordy. All rights reserved.
+//
+
+import Foundation

--- a/Common/Sources/Extension/adaptive+.swift
+++ b/Common/Sources/Extension/adaptive+.swift
@@ -1,0 +1,22 @@
+//
+//  CGFloat+.swift
+//  Common
+//
+//  Created by 한지석 on 7/4/24.
+//  Copyright © 2024 com.recordy. All rights reserved.
+//
+
+import UIKit
+import Foundation
+
+extension CGFloat {
+  var 
+  
+  private var adaptiveWidthRatio: CGFloat {
+    return UIScreen.main.bounds.width / 375
+  }
+
+  private var adaptiveHeightRatio: CGFloat {
+    return UIScreen.main.bounds.height / 812
+  }
+}

--- a/Common/Sources/Extension/adaptive+.swift
+++ b/Common/Sources/Extension/adaptive+.swift
@@ -1,5 +1,5 @@
 //
-//  CGFloat+.swift
+//  adaptive+.swift
 //  Common
 //
 //  Created by 한지석 on 7/4/24.
@@ -10,13 +10,39 @@ import UIKit
 import Foundation
 
 extension CGFloat {
-  var 
-  
+  public var adaptiveWidth: CGFloat {
+    self * adaptiveWidthRatio
+  }
+
+  public var adaptiveHeight: CGFloat {
+    self * adaptiveHeightRatio
+  }
+
   private var adaptiveWidthRatio: CGFloat {
-    return UIScreen.main.bounds.width / 375
+    UIScreen.main.bounds.width / 375
   }
 
   private var adaptiveHeightRatio: CGFloat {
-    return UIScreen.main.bounds.height / 812
+    UIScreen.main.bounds.height / 812
+  }
+}
+
+extension Int {
+  public var adaptiveWidth: CGFloat {
+    CGFloat(self).adaptiveWidth
+  }
+
+  public var adaptiveHeight: CGFloat {
+    CGFloat(self).adaptiveHeight
+  }
+}
+
+extension Double {
+  public var adaptiveWidth: CGFloat {
+    CGFloat(self).adaptiveWidth
+  }
+
+  public var adaptiveHeight: CGFloat {
+    CGFloat(self).adaptiveHeight
   }
 }

--- a/Core/Project.swift
+++ b/Core/Project.swift
@@ -14,5 +14,10 @@ let project = Project.makeModule(
   name: moduleName,
   destinations: [.iPhone],
   product: .staticFramework,
-  bundleId: moduleName
+  bundleId: moduleName,
+  dependencies: [
+    .external(name: "KakaoSDKAuth", condition: .none),
+    .external(name: "KakaoSDKCommon", condition: .none),
+    .external(name: "KakaoSDKUser", condition: .none)
+  ]
 )

--- a/Core/Sources/Photos/PhotoKitManager.swift
+++ b/Core/Sources/Photos/PhotoKitManager.swift
@@ -1,0 +1,9 @@
+//
+//  PhotoKitManager.swift
+//  Core
+//
+//  Created by 한지석 on 7/3/24.
+//  Copyright © 2024 com.recordy. All rights reserved.
+//
+
+import Foundation

--- a/Core/Sources/Photos/PhotoKitManager.swift
+++ b/Core/Sources/Photos/PhotoKitManager.swift
@@ -6,4 +6,30 @@
 //  Copyright © 2024 com.recordy. All rights reserved.
 //
 
-import Foundation
+import UIKit
+import Photos
+
+public final class PhotoKitManager {
+  static public func getAssetThumbnail(
+    asset: PHAsset,
+    size: CGSize
+  ) -> UIImage? {
+    let manager = PHImageManager.default()
+    let options = PHImageRequestOptions()
+    options.isSynchronous = true
+    options.isNetworkAccessAllowed = true
+    options.deliveryMode = .highQualityFormat
+    
+    var thumbnail: UIImage?
+    manager.requestImage(
+      for: asset,
+      targetSize: size,
+      contentMode: .aspectFill,
+      options: options
+    ) { (image, info) in
+      guard let thumbnailUnwrapped = image else {return}
+      thumbnail = thumbnailUnwrapped
+    }
+    return thumbnail
+  }
+}

--- a/Presentation/Project.swift
+++ b/Presentation/Project.swift
@@ -19,6 +19,8 @@ let project = Project.makeModule(
     .Project.Core,
     .Project.Common,
     .external(name: "SnapKit", condition: .none),
-    .external(name: "Then", condition: .none)
+    .external(name: "Then", condition: .none),
+    .external(name: "RxSwift", condition: .none),
+    .external(name: "RxCocoa", condition: .none)
   ]
 )

--- a/Presentation/Sources/UploadVideo/Cell/VideoCell.swift
+++ b/Presentation/Sources/UploadVideo/Cell/VideoCell.swift
@@ -1,0 +1,13 @@
+//
+//  VideoCell.swift
+//  Presentation
+//
+//  Created by 한지석 on 7/2/24.
+//  Copyright © 2024 com.recordy. All rights reserved.
+//
+
+import UIKit
+
+class VideoCell: UICollectionViewCell {
+    
+}

--- a/Presentation/Sources/UploadVideo/Cell/VideoCell.swift
+++ b/Presentation/Sources/UploadVideo/Cell/VideoCell.swift
@@ -7,7 +7,41 @@
 //
 
 import UIKit
+import Photos
+
+import Core
+
+import SnapKit
 
 class VideoCell: UICollectionViewCell {
-    
+  private let previewImageView: UIImageView = UIImageView()
+  
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    setUI()
+    setAutoLayout()
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  private func setUI() {
+    self.addSubview(previewImageView)
+  }
+  
+  private func setAutoLayout() {
+    previewImageView.snp.makeConstraints {
+      $0.verticalEdges.horizontalEdges.equalToSuperview()
+    }
+  }
+  
+  func bind(asset: PHAsset) {
+    let assetImage = PhotoKitManager.getAssetThumbnail(asset: asset, size: bounds.size)
+    previewImageView.image = assetImage
+  }
+
+  func setSelected(_ selected: Bool) {
+    contentView.backgroundColor = selected ? UIColor.black.withAlphaComponent(0.3) : UIColor.clear
+  }
 }

--- a/Presentation/Sources/UploadVideo/UploadVideoViewController.swift
+++ b/Presentation/Sources/UploadVideo/UploadVideoViewController.swift
@@ -8,23 +8,161 @@
 
 import UIKit
 
-class UploadVideoViewController: UIViewController {
+import Common
+import Photos
+import PhotosUI
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
+import SnapKit
+import Then
+import RxSwift
+import RxRelay
 
-        // Do any additional setup after loading the view.
+public class UploadVideoViewController: UIViewController {
+
+  private let warningLabel = UILabel().then {
+    $0.text = "ⓘ 최대 1분의 1080p 영상을 올려주세요."
+    $0.textColor = CommonAsset.recordyGrey03.color
+    $0.font = RecordyFont.caption.font
+  }
+  private let nextButton = UIButton().then {
+    $0.setTitle("다음", for: .normal)
+    $0.titleLabel?.font = RecordyFont.button1.font
+    $0.setTitleColor(.white, for: .normal)
+    $0.backgroundColor = .black
+    $0.cornerRadius(12)
+  }
+  var collectionView: UICollectionView? = nil
+  var assets: [PHAsset] = []
+  var viewModel = UploadVideoViewModel()
+
+  private let disposeBag = DisposeBag()
+  private let fetchVideosRelay = PublishRelay<Void>()
+  private let selectedVideoRelay = PublishRelay<IndexPath>()
+
+  public override func viewDidLoad() {
+    super.viewDidLoad()
+    setUpCollectionView()
+    setStyle()
+    setUI()
+    setAutoLayout()
+    bind()
+  }
+
+  private func setStyle() {
+    self.title = "영상 선택"
+  }
+
+  private func setUI() {
+    self.view.addSubview(self.warningLabel)
+    self.view.addSubview(self.collectionView!)
+    self.view.addSubview(self.nextButton)
+  }
+
+  private func setAutoLayout() {
+    self.nextButton.snp.makeConstraints {
+      $0.bottom.equalTo(view.safeAreaLayoutGuide).offset(-14.adaptiveHeight)
+      $0.horizontalEdges.equalToSuperview().inset(20.adaptiveWidth)
+      $0.height.equalTo(54.adaptiveHeight)
     }
-    
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    self.warningLabel.snp.makeConstraints {
+      $0.top.equalTo(view.safeAreaLayoutGuide).offset(9.adaptiveHeight)
+      $0.centerX.equalToSuperview()
     }
-    */
+    self.collectionView!.snp.makeConstraints {
+      $0.top.equalTo(warningLabel.snp.bottom).offset(22.adaptiveHeight)
+      $0.bottom.horizontalEdges.equalToSuperview()
+    }
+  }
 
+  private func setUpCollectionView() {
+    let layout = UICollectionViewFlowLayout()
+    self.collectionView = UICollectionView(
+      frame: .zero,
+      collectionViewLayout: layout
+    )
+    self.collectionView!.register(
+      VideoCell.self,
+      forCellWithReuseIdentifier: VideoCell.cellIdentifier
+    )
+    self.collectionView!.rx.setDelegate(self).disposed(by: disposeBag)
+  }
+
+  func bind() {
+    let input = UploadVideoViewModel.Input(
+      fetchVideos: fetchVideosRelay,
+      selectedVideo: selectedVideoRelay
+    )
+    let output = viewModel.transform(input: input)
+
+    output.asset
+      .drive(
+        collectionView!.rx.items(
+          cellIdentifier: VideoCell.cellIdentifier,
+          cellType: VideoCell.self
+        )
+      ) { (row, asset, cell) in
+        cell.bind(asset: asset)
+        cell.setSelected(
+          self.viewModel.isSelected(
+            indexPath: IndexPath(
+              row: row,
+              section: 0
+            )
+          )
+        )
+      }
+      .disposed(by: disposeBag)
+
+    output.fetchStatus
+      .drive(onNext: { success in
+        if !success {
+          print("Permission denied")
+        }
+      })
+      .disposed(by: disposeBag)
+
+    collectionView!.rx.itemSelected
+      .bind(to: selectedVideoRelay)
+      .disposed(by: disposeBag)
+
+
+    output.selectedIndexPath
+      .drive { [weak self] indexPath in
+        self?.collectionView!.reloadData()
+      }
+      .disposed(by: disposeBag)
+
+    fetchVideosRelay.accept(())
+  }
+}
+
+extension UploadVideoViewController: UICollectionViewDelegateFlowLayout {
+  public func collectionView(
+    _ collectionView: UICollectionView,
+    layout collectionViewLayout: UICollectionViewLayout,
+    sizeForItemAt indexPath: IndexPath
+  ) -> CGSize {
+    let padding: CGFloat = 4
+    let width: CGFloat = (UIScreen.main.bounds.width - padding * 4) / 4
+    return CGSize(
+      width: width,
+      height: width
+    )
+  }
+
+  public func collectionView(
+    _ collectionView: UICollectionView,
+    layout collectionViewLayout: UICollectionViewLayout,
+    minimumLineSpacingForSectionAt section: Int
+  ) -> CGFloat {
+    return 4
+  }
+
+  public func collectionView(
+    _ collectionView: UICollectionView,
+    layout collectionViewLayout: UICollectionViewLayout,
+    minimumInteritemSpacingForSectionAt section: Int
+  ) -> CGFloat {
+    return 4
+  }
 }

--- a/Presentation/Sources/UploadVideo/UploadVideoViewController.swift
+++ b/Presentation/Sources/UploadVideo/UploadVideoViewController.swift
@@ -1,0 +1,30 @@
+//
+//  UploadVideoViewController.swift
+//  Presentation
+//
+//  Created by 한지석 on 7/2/24.
+//  Copyright © 2024 com.recordy. All rights reserved.
+//
+
+import UIKit
+
+class UploadVideoViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/Presentation/Sources/UploadVideo/UploadVideoViewModel.swift
+++ b/Presentation/Sources/UploadVideo/UploadVideoViewModel.swift
@@ -1,0 +1,9 @@
+//
+//  UploadVideoViewModel.swift
+//  Presentation
+//
+//  Created by 한지석 on 7/3/24.
+//  Copyright © 2024 com.recordy. All rights reserved.
+//
+
+import Foundation

--- a/Presentation/Sources/UploadVideo/UploadVideoViewModel.swift
+++ b/Presentation/Sources/UploadVideo/UploadVideoViewModel.swift
@@ -7,3 +7,102 @@
 //
 
 import Foundation
+import Photos
+import UIKit
+
+import RxSwift
+import RxCocoa
+
+final class UploadVideoViewModel {
+
+  /// Relay VS Subject
+  /// Relay - 에러처리가 필요 없을 경우, UI 이벤트에 적합
+  /// Subject - 에러처리를 해야할 경우
+  /// PublishRelay는 주로 UI 이벤트와 같은 에러가 필요 없는 간단한 이벤트 스트림에 적합
+  /// PublishSubject는 에러 처리가 필요한 스트림에 적합합니
+  struct Input {
+    let fetchVideos: PublishRelay<Void>
+    let selectedVideo: PublishRelay<IndexPath>
+  }
+
+  struct Output {
+    let asset: Driver<[PHAsset]>
+    let fetchStatus: Driver<Bool>
+    let selectedIndexPath: Driver<IndexPath?>
+  }
+
+  private let disposeBag = DisposeBag()
+
+  private let assetsRelay = BehaviorRelay<[PHAsset]>(value: [])
+  private let fetchStatusRelay = PublishRelay<Bool>()
+  private let selectedIndexPathRelay = BehaviorRelay<IndexPath?>(value: nil)
+
+  func transform(input: Input) -> Output {
+    input.fetchVideos
+      .subscribe(onNext: { [weak self] in
+        self?.fetchVideosFromGallery()
+      })
+      .disposed(by: disposeBag)
+
+    input.selectedVideo
+      .subscribe { [weak self] indexPath in
+        self?.selectedIndexPathRelay.accept(indexPath)
+      }
+      .disposed(by: disposeBag)
+
+    return Output(
+       asset: assetsRelay.asDriver(),
+       fetchStatus: fetchStatusRelay.asDriver(onErrorJustReturn: false),
+       selectedIndexPath: selectedIndexPathRelay.asDriver()
+     )
+  }
+
+  private func fetchVideosFromGallery() {
+    getPhotoPermission { [weak self] granted in
+      guard granted else {
+        self?.fetchStatusRelay.accept(false)
+        return
+      }
+      self?.loadAssets()
+    }
+  }
+
+  private func getPhotoPermission(completionHandler: @escaping (Bool) -> Void) {
+    guard PHPhotoLibrary.authorizationStatus() != .authorized else {
+      completionHandler(true)
+      return
+    }
+    PHPhotoLibrary.requestAuthorization(for: .readWrite) { status in
+      switch status {
+      case .authorized, .limited:
+        completionHandler(true)
+      default:
+        completionHandler(false)
+      }
+    }
+  }
+
+  private func loadAssets() {
+    let fetchOptions = PHFetchOptions()
+    fetchOptions.predicate = NSPredicate(
+      format: "mediaType == %d",
+      PHAssetMediaType.video.rawValue
+    )
+    
+    let allVideos = PHAsset.fetchAssets(
+      with: .video,
+      options: fetchOptions
+    )
+    var videos: [PHAsset] = []
+    allVideos.enumerateObjects { (asset, _, _) in
+      videos.append(asset)
+    }
+
+    self.assetsRelay.accept(videos.reversed())
+    self.fetchStatusRelay.accept(true)
+  }
+
+  func isSelected(indexPath: IndexPath) -> Bool {
+    return indexPath == selectedIndexPathRelay.value
+  }
+}

--- a/Tuist/Package.resolved
+++ b/Tuist/Package.resolved
@@ -1,12 +1,12 @@
 {
   "pins" : [
     {
-      "identity" : "alamofire",
+      "identity" : "rxswift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Alamofire/Alamofire",
+      "location" : "https://github.com/ReactiveX/RxSwift.git",
       "state" : {
-        "revision" : "f455c2975872ccd2d9c81594c658af65716e9b9a",
-        "version" : "5.9.1"
+        "revision" : "b06a8c8596e4c3e8e7788e08e720e3248563ce6a",
+        "version" : "6.7.1"
       }
     },
     {

--- a/Tuist/Package.resolved
+++ b/Tuist/Package.resolved
@@ -1,12 +1,12 @@
 {
   "pins" : [
     {
-      "identity" : "rxswift",
+      "identity" : "alamofire",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ReactiveX/RxSwift.git",
+      "location" : "https://github.com/Alamofire/Alamofire",
       "state" : {
-        "revision" : "b06a8c8596e4c3e8e7788e08e720e3248563ce6a",
-        "version" : "6.7.1"
+        "revision" : "f455c2975872ccd2d9c81594c658af65716e9b9a",
+        "version" : "5.9.1"
       }
     },
     {
@@ -16,6 +16,15 @@
       "state" : {
         "branch" : "master",
         "revision" : "e9e649d3ba823c3673867d3d09010fc77005a940"
+      }
+    },
+    {
+      "identity" : "rxswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ReactiveX/RxSwift.git",
+      "state" : {
+        "revision" : "b06a8c8596e4c3e8e7788e08e720e3248563ce6a",
+        "version" : "6.7.1"
       }
     },
     {

--- a/Tuist/Package.resolved
+++ b/Tuist/Package.resolved
@@ -1,0 +1,41 @@
+{
+  "pins" : [
+    {
+      "identity" : "alamofire",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Alamofire/Alamofire",
+      "state" : {
+        "revision" : "f455c2975872ccd2d9c81594c658af65716e9b9a",
+        "version" : "5.9.1"
+      }
+    },
+    {
+      "identity" : "kakao-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kakao/kakao-ios-sdk",
+      "state" : {
+        "branch" : "master",
+        "revision" : "e9e649d3ba823c3673867d3d09010fc77005a940"
+      }
+    },
+    {
+      "identity" : "snapkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SnapKit/SnapKit",
+      "state" : {
+        "revision" : "2842e6e84e82eb9a8dac0100ca90d9444b0307f4",
+        "version" : "5.7.1"
+      }
+    },
+    {
+      "identity" : "then",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/devxoul/Then",
+      "state" : {
+        "revision" : "e421a7b3440a271834337694e6050133a3958bc7",
+        "version" : "2.7.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
   dependencies: [
     .package(url: "https://github.com/SnapKit/SnapKit", from: "5.0.1"),
     .package(url: "https://github.com/devxoul/Then", from: "2.0.0"),
-    .package(url: "https://github.com/kakao/kakao-ios-sdk", branch: "master")
+    .package(url: "https://github.com/kakao/kakao-ios-sdk", branch: "master"),
     .package(url: "https://github.com/ReactiveX/RxSwift.git", from: "6.0.0")
   ]
 )

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -17,5 +17,6 @@ let package = Package(
   dependencies: [
     .package(url: "https://github.com/SnapKit/SnapKit", from: "5.0.1"),
     .package(url: "https://github.com/devxoul/Then", from: "2.0.0"),
+    .package(url: "https://github.com/ReactiveX/RxSwift.git", from: "6.0.0")
   ]
 )

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -13,10 +13,10 @@ import PackageDescription
 #endif
 
 let package = Package(
-    name: "Recordy-iOS",
-    dependencies: [
-        // Add your own dependencies here:
-        // .package(url: "https://github.com/Alamofire/Alamofire", from: "5.0.0"),
-        // You can read more about dependencies here: https://docs.tuist.io/documentation/tuist/dependencies
-    ]
+  name: "Recordy-iOS",
+  dependencies: [
+    .package(url: "https://github.com/SnapKit/SnapKit", from: "5.0.1"),
+    .package(url: "https://github.com/devxoul/Then", from: "2.0.0"),
+    .package(url: "https://github.com/kakao/kakao-ios-sdk", branch: "master")
+  ]
 )

--- a/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
@@ -21,7 +21,8 @@ extension Project {
     resources: ResourceFileElements? = nil,
     entitlements: Entitlements? = nil,
     dependencies: [TargetDependency] = [],
-    target: Target? = nil
+    target: Target? = nil,
+    settings: Settings? = nil
   ) -> Project {
 
     let target = Target.target(
@@ -35,7 +36,8 @@ extension Project {
       resources: resources,
       entitlements: entitlements,
       scripts: [],
-      dependencies: dependencies
+      dependencies: dependencies,
+      settings: settings
     )
 
     return Project(


### PR DESCRIPTION
## 🔍 PR Content
<!-- PR 내용을 체크박스로 작성 -->
- 영상 불러오기, 선택 구현
- 필요 Extension 구현(cellIdentifier, cornerRadius, 반응형)
- 라이브러리 세팅, Info.plist 세팅(사진 접근 권한)

## 📸 Screenshot
<img src="https://github.com/Team-Recordy/Recordy-iOS/assets/49385546/a137b8ca-5660-4b37-9e45-10a5aaa015f7" width="250"/>
<img src="https://github.com/Team-Recordy/Recordy-iOS/assets/49385546/e3a0beda-f48b-4c09-8ac6-efc69561970d" width="250"/>

- 좌측은 선택, 우측은 미선택

## 📍 PR Point 
- PR이 길어질 수 있어 다음 작업과 이어서 할 예정입니다. (영상 업로드 하는 과정까지의 화면)
- 이해되지 않는 부분이 있으면 댓글 해주세요!!

## ✏️ Notice
- 현재 피그마에서 375 * 812의 크기로 작업이 진행되어 빌드되는 기종의 가로, 세로를 해당 크기만큼 나누어 비율을 지정하여 오토레이아웃을 지정하면 됩니다!
- cornerRadius 지정 시 해당 컴포넌트.cornerRadius(ratio)를 해주시면 됩니다.
- CollectionViewCell.cellIdentifier로 identifier를 가져올 수 있습니다.

- close #10 
