### PR TITLE
[Refactoring] SignupViewController 리팩토링

### DIFF
--- a/Common/Sources/Components/RecordyProgressView.swift
+++ b/Common/Sources/Components/RecordyProgressView.swift
@@ -16,8 +16,8 @@ public final class RecordyProgressView: UIView {
     didSet {
       self.progressBarView.snp.remakeConstraints {
         $0.leading.equalToSuperview()
-        $0.top.equalToSuperview().offset(-1)
-        $0.bottom.equalToSuperview().offset(1)
+        $0.top.equalToSuperview().offset(-2)
+        $0.bottom.equalToSuperview().offset(2)
         $0.width.equalToSuperview().multipliedBy(self.ratio)
       }
       

--- a/Common/Sources/Components/RecordyTextField.swift
+++ b/Common/Sources/Components/RecordyTextField.swift
@@ -8,23 +8,18 @@
 
 import UIKit
 
-public protocol RecordyTextFieldStateDelegate: AnyObject {
-  func state(_ currentState: RecordyTextFieldState)
-}
-
-
 public final class RecordyTextField: UITextField {
   
-  public weak var stateDelegate: RecordyTextFieldStateDelegate?
-  var style: RecordyTextFieldStyle {
+  public var onStateChange: ((RecordyTextFieldState) -> Void)?
+  public var style: RecordyTextFieldStyle {
     didSet { setStyle(style) }
   }
   public var textState: RecordyTextFieldState = .unselected {
-     didSet {
-       setState(textState)
-     }
-   }
-
+    didSet {
+      setState(textState)
+    }
+  }
+  
   public init(
     frame: CGRect = .zero,
     style: RecordyTextFieldStyle = .unselected,
@@ -41,12 +36,13 @@ public final class RecordyTextField: UITextField {
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
-
-  private func setState(_ style: RecordyTextFieldState) {
+  
+  func setState(_ style: RecordyTextFieldState) {
     self.layer.borderColor = style.borderColor.cgColor
     self.layer.borderWidth = style.borderWidth
+    onStateChange?(style)
   }
-
+  
   func setStyle(_ style: RecordyTextFieldStyle) {
     self.setLayer(
       borderColor: style.borderColor,
@@ -83,9 +79,9 @@ extension RecordyTextField: UITextFieldDelegate {
     let matches = regex.matches(in: updatedText, range: NSRange(location: 0, length: updatedText.utf16.count))
     
     if matches.isEmpty {
-      stateDelegate?.state(.error)
+      onStateChange?(.error)
     } else {
-      stateDelegate?.state(.selected)
+      onStateChange?(.selected)
     }
     return true
   }
@@ -95,13 +91,13 @@ extension RecordyTextField: UITextFieldDelegate {
   }
   
   public func textFieldShouldEndEditing(_ textField: UITextField) -> Bool {
-    stateDelegate?.state(.unselected)
+    onStateChange?(.unselected)
     return true
   }
   
   public func textFieldShouldReturn(_ textField: UITextField) -> Bool {
     textField.resignFirstResponder()
-    stateDelegate?.state(.unselected)
+    onStateChange?(.unselected)
     return true
   }
 }

--- a/Common/Sources/Extension/String+.swift
+++ b/Common/Sources/Extension/String+.swift
@@ -25,7 +25,7 @@ extension String {
     )
     return boundingBox.height
   }
-
+  
   public func timeStringToSeconds() -> Int {
     let components = self.split(separator: ":")
     guard components.count == 2,
@@ -35,7 +35,7 @@ extension String {
     }
     return (minutes * 60) + seconds
   }
-
+  
   public func removeQueryParameters() -> String? {
     if let urlComponents = URLComponents(string: self) {
       var modifiedComponents = urlComponents
@@ -44,9 +44,16 @@ extension String {
     }
     return nil
   }
-
+  
   public func keywordEncode() -> String? {
     guard let data = self.data(using: .utf8) else { return nil }
     return data.base64EncodedString()
+  }
+  
+  public func matches(pattern: String) -> Bool {
+    guard let regex = try? NSRegularExpression(pattern: pattern) else { return false }
+    let range = NSRange(location: 0, length: self.utf16.count)
+    let matches = regex.matches(in: self, range: range)
+    return !matches.isEmpty
   }
 }

--- a/Presentation/Sources/Signup/Controller/SignupViewController.swift
+++ b/Presentation/Sources/Signup/Controller/SignupViewController.swift
@@ -15,11 +15,11 @@ import SnapKit
 
 @available(iOS 16.0, *)
 public final class SignupViewController: UIViewController {
-  
-  var rootView: UIView = UIView()
+
   let totalPages = 3
   var currentPage = 0
   
+  var rootView: UIView = UIView()
   let signupView = SignupView()
   let termsView = TermsView()
   let nicknameView = NicknameView()

--- a/Presentation/Sources/Signup/Controller/SignupViewController.swift
+++ b/Presentation/Sources/Signup/Controller/SignupViewController.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2024 com.recordy. All rights reserved.
 //
 
-
 import UIKit
 
 import Core
@@ -21,11 +20,15 @@ public final class SignupViewController: UIViewController {
   let totalPages = 3
   var currentPage = 0
   
+  let signupView = SignupView()
+  let termsView = TermsView()
+  let nicknameView = NicknameView()
+  let completeView = CompleteView()
+  
   public override func viewDidLoad() {
     super.viewDidLoad()
-    self.title = "회원가입"
     showTermsView()
-    SignupView().progressView.updateProgress(
+    signupView.progressView.updateProgress(
       currentPage: currentPage,
       totalPages: totalPages
     )
@@ -39,21 +42,23 @@ public final class SignupViewController: UIViewController {
       $0.edges.equalToSuperview()
     }
     rootView = newView
-    view.addSubview(SignupView().progressView)
-    SignupView().progressView.snp.remakeConstraints {
+    
+    view.addSubview(signupView.progressView)
+    signupView.progressView.snp.remakeConstraints {
       $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(12)
       $0.leading.trailing.equalToSuperview().inset(20)
       $0.height.equalTo(6)
     }
   }
   
+  @objc
   func showTermsView() {
-    let termsView = TermsView()
     termsView.nextButton.addTarget(
       self,
       action: #selector(showNicknameView),
       for: .touchUpInside
     )
+    self.title = "이용 약관"
     switchView(termsView)
   }
   
@@ -61,44 +66,41 @@ public final class SignupViewController: UIViewController {
   func showNicknameView() {
     if let termsView = rootView as? TermsView, termsView.areAllButtonsActive() {
       currentPage += 1
-      SignupView().progressView.updateProgress(
+      signupView.progressView.updateProgress(
         currentPage: currentPage,
         totalPages: totalPages
       )
-      NicknameView().nextButton.addTarget(
+      nicknameView.nextButton.addTarget(
         self,
         action: #selector(showCompleteView),
         for: .touchUpInside
       )
-      NicknameView().nicknameTextField.stateDelegate = self
-      switchView(NicknameView())
+      self.title = "닉네임 설정"
+      switchView(nicknameView)
     }
-    
   }
   
   @objc
   func showCompleteView() {
-    guard NicknameView().nextButton.buttonState == .active else { return }
+    guard nicknameView.nextButton.buttonState == .active else { return }
     currentPage += 1
-    SignupView().progressView.updateProgress(
+    signupView.progressView.updateProgress(
       currentPage: currentPage,
       totalPages: totalPages
     )
-    let completeView = CompleteView()
     completeView.completeButton.buttonState = .active
     completeView.completeButton.addTarget(
       self,
-      action: #selector(
-        completeSignup
-      ),
+      action: #selector(completeSignup),
       for: .touchUpInside
     )
+    self.title = "회원가입 완료"
     switchView(completeView)
   }
   
   @objc
   func completeSignup() {
-    guard let text = NicknameView().nicknameTextField.text else { return }
+    guard let text = nicknameView.nicknameTextField.text else { return }
     let apiProvider = APIProvider<APITarget.Users>()
     let userId = UserDefaults.standard.integer(forKey: "userId")
     let request = DTO.SignUpRequest(
@@ -112,16 +114,8 @@ public final class SignupViewController: UIViewController {
         tabBarController.modalPresentationStyle = .fullScreen
         self.present(tabBarController, animated: false)
       case .failure:
-        print("실패 팝업")
+        print("failed to login")
       }
     }
-  }
-}
-
-@available(iOS 16.0, *)
-extension SignupViewController: RecordyTextFieldStateDelegate {
-  public func state(_ currentState: Common.RecordyTextFieldState) {
-    self.textFieldState = currentState
-    nicknameView.state(currentState)
   }
 }

--- a/Presentation/Sources/Signup/View/NicknameView.swift
+++ b/Presentation/Sources/Signup/View/NicknameView.swift
@@ -6,7 +6,6 @@ import Core
 final class NicknameView: UIView {
   
   var textFieldCount = "0"
-  private var isUsernameTakenFlag = false
   
   let gradientView = RecordyGradientView()
   let nicknameText = UILabel()
@@ -22,6 +21,8 @@ final class NicknameView: UIView {
     setAutoLayout()
     setTextFieldObserver()
     setTextFieldStateHandler()
+    
+    nicknameTextField.delegate = self
   }
   
   deinit {
@@ -41,6 +42,7 @@ final class NicknameView: UIView {
       $0.textColor = CommonAsset.recordyGrey01.color
       $0.numberOfLines = 0
       $0.textAlignment = .right
+      $0.setLineSpacing(lineHeightMultiple: 1.3)
     }
     
     nextButton.do {

--- a/Presentation/Sources/Signup/View/NicknameView.swift
+++ b/Presentation/Sources/Signup/View/NicknameView.swift
@@ -148,21 +148,15 @@ final class NicknameView: UIView {
     }
   }
   
-  private func validateTextField() {
+  func validateTextField() {
     guard let text = nicknameTextField.text else {
       nicknameTextField.onStateChange?(.error)
       return
     }
     
     let pattern = "^[가-힣0-9._]{1,10}$"
-    let regex = try! NSRegularExpression(pattern: pattern)
-    let matches = regex.matches(in: text, range: NSRange(location: 0, length: text.utf16.count))
     
-    if matches.isEmpty {
-      nicknameTextField.onStateChange?(.error)
-      errorLabel.text = "ⓘ 한글, 숫자, 밑줄 및 마침표만 사용할 수 있어요"
-      errorLabel.textColor = CommonAsset.recordyAlert.color
-    } else {
+    if text.matches(pattern: pattern) {
       getCheckNicknameRequest { isSuccess in
         if isSuccess {
           self.errorLabel.text = "사용 가능한 닉네임이에요"
@@ -174,6 +168,10 @@ final class NicknameView: UIView {
           self.errorLabel.textColor = CommonAsset.recordyAlert.color
         }
       }
+    } else {
+      nicknameTextField.onStateChange?(.error)
+      errorLabel.text = "ⓘ 한글, 숫자, 밑줄 및 마침표만 사용할 수 있어요"
+      errorLabel.textColor = CommonAsset.recordyAlert.color
     }
   }
 }

--- a/Presentation/Sources/Signup/View/NicknameView.swift
+++ b/Presentation/Sources/Signup/View/NicknameView.swift
@@ -21,8 +21,6 @@ final class NicknameView: UIView {
     setAutoLayout()
     setTextFieldObserver()
     setTextFieldStateHandler()
-    
-    nicknameTextField.delegate = self
   }
   
   deinit {
@@ -61,6 +59,8 @@ final class NicknameView: UIView {
       $0.font = RecordyFont.caption2.font
       $0.textColor = CommonAsset.recordyAlert.color
     }
+    
+    nicknameTextField.delegate = self
   }
   
   func setUI() {

--- a/Presentation/Sources/Signup/View/SignupView.swift
+++ b/Presentation/Sources/Signup/View/SignupView.swift
@@ -1,0 +1,51 @@
+//
+//  SignupView.swift
+//  Presentation
+//
+//  Created by Chandrala on 8/12/24.
+//  Copyright © 2024 com.recordy. All rights reserved.
+//
+
+import UIKit
+
+import Core
+import Common
+
+import UIKit
+import SnapKit
+
+class SignupView: UIView {
+  
+  let gradientView = RecordyGradientView()
+  let progressView = RecordyProgressView()
+  
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    setUI()
+    setLayout()
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  private func setUI() {
+    self.addSubviews(
+      gradientView,
+      progressView
+    )
+  }
+  
+  private func setLayout() {
+    progressView.snp.makeConstraints {
+      $0.top.equalTo(self.safeAreaLayoutGuide.snp.top).offset(12)
+      $0.leading.trailing.equalToSuperview().inset(20)
+      $0.height.equalTo(6.adaptiveHeight)
+    }
+    
+    gradientView.snp.makeConstraints {
+      $0.top.horizontalEdges.equalToSuperview()
+      $0.height.equalTo(400.adaptiveHeight)
+    }
+  }
+}

--- a/Presentation/Sources/Signup/View/SignupView.swift
+++ b/Presentation/Sources/Signup/View/SignupView.swift
@@ -11,7 +11,6 @@ import UIKit
 import Core
 import Common
 
-import UIKit
 import SnapKit
 
 class SignupView: UIView {

--- a/Presentation/Sources/Signup/View/TermsView.swift
+++ b/Presentation/Sources/Signup/View/TermsView.swift
@@ -51,6 +51,7 @@ final class TermsView: UIView {
       $0.font = RecordyFont.title1.font
       $0.textColor = CommonAsset.recordyGrey01.color
       $0.numberOfLines = 0
+      $0.setLineSpacing(lineHeightMultiple: 1.3)
     }
     
     agreeToAllButton.do {

--- a/Presentation/Sources/Signup/View/TermsView.swift
+++ b/Presentation/Sources/Signup/View/TermsView.swift
@@ -199,7 +199,6 @@ final class TermsView: UIView {
   private func updateNextButtonState() {
     let allTermsAgreed = termButton1.currentState == .agree && termButton2.currentState == .agree && termButton3.currentState == .agree
     nextButton.buttonState = allTermsAgreed ? .active : .inactive
-    print("updatenextButtonState")
   }
   
   func areAllButtonsActive() -> Bool {


### PR DESCRIPTION
## 🔍 PR Content
- 다음 버튼을 눌렀을 때 View를 교체하는 함수 수정
- 다음 버튼을 눌렀을 때 NavigationController Title 변경
- SignupViewController를 MVC로 추상화

## 📍 PR Point 
- 컴포넌트의 상태 전달 방식을 Closure로 변경했습니다.
- Signup뷰를 Controller는 함수처리, View는 UI를 담당하도록 분리했습니다.
- 불필요한 코드를 제거했습니다.

close #133 